### PR TITLE
Only requests permissions that we need on Android

### DIFF
--- a/src/mediafilepicker.android.ts
+++ b/src/mediafilepicker.android.ts
@@ -153,7 +153,14 @@ export class Mediafilepicker extends Observable implements MediaPickerInterface 
 
         let t = this;
 
-        permissions.requestPermission([android.Manifest.permission.CAMERA, android.Manifest.permission.RECORD_AUDIO, android.Manifest.permission.WRITE_EXTERNAL_STORAGE], "Need these permissions to access files")
+        const requestPermissions = [android.Manifest.permission.WRITE_EXTERNAL_STORAGE];
+        if (type === "image" || type === "video") {
+            requestPermissions.push(android.Manifest.permission.CAMERA);
+        } else if (type === "audio") {
+            requestPermissions.push(android.Manifest.permission.RECORD_AUDIO);
+        }
+
+        permissions.requestPermission(requestPermissions, "Need these permissions to access files")
             .then(function () {
                 t.handleOnlyCaptureMode(type, options);
             })
@@ -264,7 +271,14 @@ export class Mediafilepicker extends Observable implements MediaPickerInterface 
 
         let t = this;
 
-        permissions.requestPermission([android.Manifest.permission.CAMERA, android.Manifest.permission.RECORD_AUDIO, android.Manifest.permission.WRITE_EXTERNAL_STORAGE], "Need these permissions to access files")
+        const requestPermissions = [android.Manifest.permission.WRITE_EXTERNAL_STORAGE];
+        if (pickerType === Constant.REQUEST_CODE_TAKE_IMAGE || pickerType === Constant.REQUEST_CODE_TAKE_VIDEO) {
+            requestPermissions.push(android.Manifest.permission.CAMERA);
+        } else if (pickerType === Constant.REQUEST_CODE_TAKE_AUDIO) {
+            requestPermissions.push(android.Manifest.permission.RECORD_AUDIO);
+        }
+
+        permissions.requestPermission(requestPermissions, "Need these permissions to access files")
             .then(function () {
                 app.android.foregroundActivity.startActivityForResult(intent, pickerType);
             })

--- a/src/mediafilepicker.android.ts
+++ b/src/mediafilepicker.android.ts
@@ -272,9 +272,9 @@ export class Mediafilepicker extends Observable implements MediaPickerInterface 
         let t = this;
 
         const requestPermissions = [android.Manifest.permission.WRITE_EXTERNAL_STORAGE];
-        if (pickerType === Constant.REQUEST_CODE_TAKE_IMAGE || pickerType === Constant.REQUEST_CODE_TAKE_VIDEO) {
+        if (pickerType === Constant.REQUEST_CODE_TAKE_IMAGE || pickerType === Constant.REQUEST_CODE_PICK_IMAGE || pickerType === Constant.REQUEST_CODE_TAKE_VIDEO || pickerType === Constant.REQUEST_CODE_PICK_VIDEO) {
             requestPermissions.push(android.Manifest.permission.CAMERA);
-        } else if (pickerType === Constant.REQUEST_CODE_TAKE_AUDIO) {
+        } else if (pickerType === Constant.REQUEST_CODE_TAKE_AUDIO || pickerType === Constant.REQUEST_CODE_PICK_AUDIO) {
             requestPermissions.push(android.Manifest.permission.RECORD_AUDIO);
         }
 


### PR DESCRIPTION
We are not using the audio picker, but the plugin was still asking for Audio record permission, something we did not like. I made this change to only ask for the permissions that the used picker(s) need on Android.