### PR TITLE
Fix ImagePicker exception

### DIFF
--- a/src/mediafilepicker.common.ts
+++ b/src/mediafilepicker.common.ts
@@ -12,7 +12,7 @@ export interface ImagePickerOptions {
     android?: {
         isCaptureMood?: boolean;
         isNeedCamera?: boolean;
-        maxNumberFiles?: Number;
+        maxNumberFiles?: number;
         isNeedFolderList?: boolean;
     };
     ios?: {


### PR DESCRIPTION
Error:
The types of 'android.maxNumberFiles' are incompatible between these types.
Type 'Number' is not assignable to type 'number'.